### PR TITLE
Add option to build for java7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,9 @@ configurations {
     provided
 }
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 version = "0.1.3"
 
 dependencies {


### PR DESCRIPTION
v0.1.1 works well at Java7.
But v0.1.3 doesn't work at Java7.

So I added option to build.gradle
